### PR TITLE
Feat: Organization Card

### DIFF
--- a/components/OrganizationCard.tsx
+++ b/components/OrganizationCard.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React from "react";
+import Image from "next/image";
+
+interface OrganizationCardProps {
+    borderColor: string;
+    organizationImage: string;
+    organizationName: string;
+    numberOfEvents: number;
+}
+
+export default function OrganizationCard({ 
+    borderColor, 
+    organizationImage, 
+    organizationName, 
+    numberOfEvents 
+}: OrganizationCardProps) {
+    return (
+        <div className={`flex items-center space-x-4 bg-white rounded-lg shadow px-4 py-3 border-l-[1rem] lg:border-l-[1.5rem] 2xl:border-l-[2rem] ${borderColor}`}>
+            <div className="w-8 h-8 xl:w-10 xl:h-10 2xl:w-16 2xl:h-16 relative flex-shrink-0">
+                <Image 
+                    src={organizationImage}
+                    alt={organizationName}
+                    fill
+                    className="rounded-full object-cover"
+                />
+            </div>
+            <div>
+                <p className="font-medium text-sm lg:text-base xl:text-lg 2xl:text-xl">{organizationName}</p>
+                <p className="text-gray-500 text-xs lg:text-sm xl:text-base 2xl:text-lg">{numberOfEvents} Events</p>
+            </div>
+        </div>
+    )
+};

--- a/components/OrganizationCard.tsx
+++ b/components/OrganizationCard.tsx
@@ -1,34 +1,41 @@
 "use client";
 import React from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 interface OrganizationCardProps {
     borderColor: string;
-    organizationImage: string;
+    organizationImage?: string;
     organizationName: string;
     numberOfEvents: number;
+    href: string;
 }
 
 export default function OrganizationCard({ 
     borderColor, 
     organizationImage, 
     organizationName, 
-    numberOfEvents 
+    numberOfEvents,
+    href
 }: OrganizationCardProps) {
+    const placeholderImage = "/images/placeholder.jpg"; // Temporary; Change this to the final placeholder
+
     return (
-        <div className={`flex items-center space-x-4 bg-white rounded-lg shadow px-4 py-3 border-l-[1rem] lg:border-l-[1.5rem] 2xl:border-l-[2rem] ${borderColor}`}>
-            <div className="w-8 h-8 xl:w-10 xl:h-10 2xl:w-16 2xl:h-16 relative flex-shrink-0">
-                <Image 
-                    src={organizationImage}
-                    alt={organizationName}
-                    fill
-                    className="rounded-full object-cover"
-                />
+        <Link href={href}>
+            <div className={`flex items-center space-x-4 bg-white rounded-lg shadow px-4 py-3 border-l-[1rem] lg:border-l-[1.5rem] 2xl:border-l-[2rem] ${borderColor}`}>
+                <div className="w-8 h-8 xl:w-10 xl:h-10 2xl:w-16 2xl:h-16 relative flex-shrink-0">
+                    <Image 
+                        src={organizationImage || placeholderImage}
+                        alt={organizationName}
+                        fill
+                        className="rounded-full object-cover"
+                    />
+                </div>
+                <div>
+                    <p className="font-medium text-sm lg:text-base xl:text-lg 2xl:text-xl">{organizationName}</p>
+                    <p className="text-gray-500 text-xs lg:text-sm xl:text-base 2xl:text-lg">{numberOfEvents} Events</p>
+                </div>
             </div>
-            <div>
-                <p className="font-medium text-sm lg:text-base xl:text-lg 2xl:text-xl">{organizationName}</p>
-                <p className="text-gray-500 text-xs lg:text-sm xl:text-base 2xl:text-lg">{numberOfEvents} Events</p>
-            </div>
-        </div>
+        </Link>
     )
 };


### PR DESCRIPTION
Create a **responsive and reusable Organization Card component**.  The card is also **clickable**. 

<img width="827" alt="Screenshot 2025-05-18 at 9 49 13 PM" src="https://github.com/user-attachments/assets/a009e0a6-d842-4e9d-86b2-375eeb14cea7" />
<img width="827" alt="Screenshot 2025-05-18 at 9 50 29 PM" src="https://github.com/user-attachments/assets/7ca8b972-2693-4895-80a5-96001020d38b" />
<img width="824" alt="Screenshot 2025-05-18 at 9 50 58 PM" src="https://github.com/user-attachments/assets/31f6b3c9-299e-41f3-858a-c434bc188634" />
<img width="822" alt="Screenshot 2025-05-18 at 9 49 55 PM" src="https://github.com/user-attachments/assets/c84516a5-8645-47aa-803e-75af67cc8832" />


Provide a **generic placeholder** feature in the component. _(Picture attached is only temporary)._
<img width="1467" alt="Screenshot 2025-05-18 at 10 05 19 PM" src="https://github.com/user-attachments/assets/fc55eb96-78c0-4ead-b90e-b8dbb6f277d0" />
